### PR TITLE
Conda init error

### DIFF
--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,2 +1,4 @@
 #!/bin/bash
+conda init
+conda config --set auto_activate_base false
 /opt/conda/envs/AE4353/bin/pip install -e .


### PR DESCRIPTION
Fixes `CondaError: Run 'conda init' before 'conda activate'`, which occurs after building the container and opening a terminal. Also prevents that the `base` env is activated.